### PR TITLE
Account for the fact that console.log is async.

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -10,7 +10,10 @@ var stream = process.stdin
 var concatStream = concat({encoding: 'string'}, function (data) {
   var output = makeJson(data)
   console.log(JSON.stringify(output))
-  if (output.length > 0) process.exit(1)
+
+  process.stdout.on('finish', function () {
+    if (output.length > 0) process.exit(1)
+  })
 })
 stream.pipe(concatStream)
 

--- a/bin.js
+++ b/bin.js
@@ -9,11 +9,8 @@ var stream = process.stdin
 
 var concatStream = concat({encoding: 'string'}, function (data) {
   var output = makeJson(data)
+  process.exitCode = output.length ? 1 : 0
   console.log(JSON.stringify(output))
-
-  process.stdout.on('finish', function () {
-    if (output.length > 0) process.exit(1)
-  })
 })
 stream.pipe(concatStream)
 


### PR DESCRIPTION
If there are a lot of results there is a chance of exiting this process before we are finished writing the results.

Wait for stdout to be finished before exiting
