### PR TITLE
Use const and let instead of var

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
 
-var makeJson = require('./index.js')
-var concat = require('concat-stream')
+const makeJson = require('./index.js')
+const concat = require('concat-stream')
 
 process.stdout.on('error', function () {})
 
-var stream = process.stdin
+const stream = process.stdin
 
-var concatStream = concat({ encoding: 'string' }, function (data) {
-  var output = makeJson(data)
+const concatStream = concat({ encoding: 'string' }, function (data) {
+  const output = makeJson(data)
   process.exitCode = output.length ? 1 : 0
   console.log(JSON.stringify(output))
 })

--- a/index.js
+++ b/index.js
@@ -2,19 +2,19 @@ module.exports = jsonify
 
 function jsonify (rawtext, opts) {
   opts = opts || { noisey: false }
-  var lines = rawtext.split('\n')
+  const lines = rawtext.split('\n')
   if (lines[lines.length - 1] === '') lines.pop()
 
-  var results = []
-  var resultMap = {}
+  const results = []
+  const resultMap = {}
   lines.forEach(function (line) {
-    var re = /\s*([A-Za-z]:)?([^:]+):([^:]+):([^:]+): (.*?)( \((.*)\))?$/.exec(line)
+    const re = /\s*([A-Za-z]:)?([^:]+):([^:]+):([^:]+): (.*?)( \((.*)\))?$/.exec(line)
     if (!re) return opts.noisey ? console.error(line) : null
     if (re[1] === undefined) re[1] = ''
 
-    var filePath = re[1] + re[2]
+    const filePath = re[1] + re[2]
 
-    var result = resultMap[filePath]
+    let result = resultMap[filePath]
     if (!result) {
       result = resultMap[filePath] = {
         filePath: re[1] + re[2],

--- a/test/exec.test.js
+++ b/test/exec.test.js
@@ -1,12 +1,12 @@
-var test = require('tape')
-var exec = require('child_process').exec
-var path = require('path')
+const test = require('tape')
+const exec = require('child_process').exec
+const path = require('path')
 
-var binfile = path.resolve(__dirname, '..', 'bin.js')
-var catfile = path.resolve(__dirname, 'data-verbose.txt')
+const binfile = path.resolve(__dirname, '..', 'bin.js')
+const catfile = path.resolve(__dirname, 'data-verbose.txt')
 
 test('return error code 1 if data passed in', function (t) {
-  var cmd = 'minicat ' + catfile + ' | node ' + binfile
+  const cmd = 'minicat ' + catfile + ' | node ' + binfile
   exec(cmd, function (err, stdout, stderr) {
     t.ok(stdout.length > 0, 'stdout is correct')
     t.equals(err.code, 1, 'correctly exits with code 1')
@@ -15,7 +15,7 @@ test('return error code 1 if data passed in', function (t) {
 })
 
 test('return error code 0 if no data passed in', function (t) {
-  var cmd = 'echo "" | node ' + binfile
+  const cmd = 'echo "" | node ' + binfile
   exec(cmd, function (err, stdout, stderr) {
     t.equals(stdout, '[]\n', 'stdout is correct')
     t.error(err, 'correctly exits without error')

--- a/test/index.js
+++ b/test/index.js
@@ -1,12 +1,12 @@
-var test = require('tape')
-var jsonify = require('../')
-var fs = require('fs')
-var path = require('path')
+const test = require('tape')
+const jsonify = require('../')
+const fs = require('fs')
+const path = require('path')
 
 test('standard-json', function (t) {
   t.plan(1)
-  var data = fs.readFileSync(path.join(__dirname, 'data.txt'), { encoding: 'utf8' })
-  var dataJson = [{
+  const data = fs.readFileSync(path.join(__dirname, 'data.txt'), { encoding: 'utf8' })
+  const dataJson = [{
     filePath: '/someplace/index.js',
     messages: [{
       line: '5',
@@ -21,15 +21,15 @@ test('standard-json', function (t) {
     }]
   }]
 
-  var output = jsonify(data)
+  const output = jsonify(data)
 
   t.deepEqual(output, dataJson, 'JSON formatted')
 })
 
 test('standard-json verbose', function (t) {
   t.plan(1)
-  var data = fs.readFileSync(path.join(__dirname, 'data-verbose.txt'), { encoding: 'utf8' })
-  var dataJson = [{
+  const data = fs.readFileSync(path.join(__dirname, 'data-verbose.txt'), { encoding: 'utf8' })
+  const dataJson = [{
     filePath: '/someplace/index.js',
     messages: [{
       line: '5',
@@ -44,15 +44,15 @@ test('standard-json verbose', function (t) {
     }]
   }]
 
-  var output = jsonify(data)
+  const output = jsonify(data)
 
   t.deepEqual(output, dataJson, 'JSON formatted')
 })
 
 test('standard-json verbose with Windows path', function (t) {
   t.plan(1)
-  var data = fs.readFileSync(path.join(__dirname, 'data-verbose-windows.txt'), { encoding: 'utf8' })
-  var dataJson = [{
+  const data = fs.readFileSync(path.join(__dirname, 'data-verbose-windows.txt'), { encoding: 'utf8' })
+  const dataJson = [{
     filePath: 'D:\\someplace\\index.js',
     messages: [{
       line: '5',
@@ -67,17 +67,17 @@ test('standard-json verbose with Windows path', function (t) {
     }]
   }]
 
-  var output = jsonify(data)
+  const output = jsonify(data)
 
   t.deepEqual(output, dataJson, 'JSON formatted')
 })
 
 test('standard-json parenthesis in message', function (t) {
   t.plan(1)
-  var data = fs.readFileSync(path.join(__dirname, 'data-paren-in-msg.txt'), { encoding: 'utf8' })
-  var dataJson = [{ filePath: '/someplace/index.js', messages: [{ column: '18', line: '1', message: 'Missing \'()\' invoking a constructor.', ruleId: undefined }] }]
+  const data = fs.readFileSync(path.join(__dirname, 'data-paren-in-msg.txt'), { encoding: 'utf8' })
+  const dataJson = [{ filePath: '/someplace/index.js', messages: [{ column: '18', line: '1', message: 'Missing \'()\' invoking a constructor.', ruleId: undefined }] }]
 
-  var output = jsonify(data)
+  const output = jsonify(data)
 
   t.deepEqual(output, dataJson, 'JSON formatted')
 })


### PR DESCRIPTION
Use `const` and `let` instead of `var` to conform to the [`no-var`](https://eslint.org/docs/rules/no-var) ESLint rule which is coming in a future version of [JavaScript Standard Style](https://standardjs.com). See https://github.com/standard/eslint-config-standard/pull/152.